### PR TITLE
Remove unused dependency: webpack-remove-empty-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "ISC",
   "devDependencies": {
     "@wordpress/scripts": "^28.3.0",
-    "path": "^0.12.7",
-    "webpack-remove-empty-scripts": "^1.0.4"
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
This PR removes the unused devDependency `webpack-remove-empty-scripts` from package.json. The project does not use this package directly or indirectly, and builds correctly without it.